### PR TITLE
fix: add missing peer dependency graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "@graphql-codegen/visitor-plugin-common": "^1.17.0",
     "auto-bind": "~4.0.0"
   },
+  "peerDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+  },
   "main": "build/src/index.js",
   "devDependencies": {
     "@graphql-codegen/cli": "^1.17.0",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`graphql-codegen-apollo-next-ssr` depends on `graphql` without declaring it as a peer dependency

Fixes https://github.com/dotansimha/graphql-code-generator/pull/4818#issuecomment-700612372

**How did you fix it?**

Added `graphql` as a peer dependency