### PR TITLE
feat: add custom context type for getApolloClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ By declaring a top level query we can save rendering time and provide a simpler 
 - `withHooks` (default: false): Customized the output by enabling/disabling the generated React Hooks.
 - `withHOC` (default: true):  Customized the output by enabling/disabling the HOC.
 - `customImports` (default: ''): full custom import declaration
+- `contextType` (default: 'any'): Contex type passed to getApolloClient
+- `contextTypeRequired` (default: false): If the context should be required when called from getServerSideProps
 - `pre` (default: ''): custom code before each function
 - `post` (default: ''):  custom code after each function
 - `apolloClientInstanceImport`(default: ''): Add apolloClient instance imports

--- a/example/codegen.yml
+++ b/example/codegen.yml
@@ -20,6 +20,8 @@ generates:
       importDocumentNodeExternallyFrom: ./graphql
       reactApolloVersion: 3
       withHooks: true
+      contextType: 'ApolloClientContext'
+      contextTypeRequired: true
       # withHOC: false
       # excludePatterns: 'getComments'
       # excludePatternsOptions: 'i'

--- a/example/src/pages/[continent].tsx
+++ b/example/src/pages/[continent].tsx
@@ -17,10 +17,10 @@ const HomePage: PageGetCountriesByCodeComp = (props) => {
   );
 };
 
-export const getStaticProps: GetServerSideProps = async ({ params }) => {
+export const getStaticProps: GetServerSideProps = async ({ params, req }) => {
   const res = await ssrGetCountriesByCode.getServerPage({
     variables: { code: params?.continent?.toString().toUpperCase() || "" },
-  });
+  }, { req });
 
   if (res.props.error || !res.props.data?.countries?.length) {
     return {
@@ -31,7 +31,7 @@ export const getStaticProps: GetServerSideProps = async ({ params }) => {
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const { props } = await ssrGetContinents.getServerPage({}, null);
+  const { props } = await ssrGetContinents.getServerPage({}, { req: undefined });
   const paths =
     props?.data?.continents.map((continent) => ({
       params: { continent: continent.code },

--- a/example/src/pages/continents.tsx
+++ b/example/src/pages/continents.tsx
@@ -1,3 +1,4 @@
+import { GetServerSideProps } from 'next';
 import { PageGetContinentsComp, ssrGetContinents } from "../generated/page";
 import Link from "next/link";
 import { withApollo } from "../withApollo";
@@ -17,8 +18,8 @@ const ContinentPage: PageGetContinentsComp = () => {
   );
 };
 
-export const getServerSideProps = async () => {
-  return await ssrGetContinents.getServerPage({});
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  return await ssrGetContinents.getServerPage({}, ctx);
 };
 
 export default withApollo(ContinentPage);

--- a/example/src/withApollo.tsx
+++ b/example/src/withApollo.tsx
@@ -1,4 +1,7 @@
-import { NextPage } from "next";
+import { 
+  NextPage,
+} from "next";
+
 import {
   ApolloClient,
   NormalizedCacheObject,
@@ -6,19 +9,36 @@ import {
   ApolloProvider,
   createHttpLink,
 } from "@apollo/client";
+import {
+  NextApiRequestCookies,
+  // @ts-ignore This path is generated at build time and conflicts otherwise
+} from 'next-server/server/api-utils';
+import { IncomingMessage } from "http";
+
+export type ApolloClientContext = {
+  req?: IncomingMessage & {
+    cookies: NextApiRequestCookies
+  }
+};
 
 export const withApollo = (Comp: NextPage) => (props: any) => {
   return (
-    <ApolloProvider client={getApolloClient(null, props.apolloState)}>
+    <ApolloProvider client={getApolloClient(undefined, props.apolloState)}>
       <Comp />
     </ApolloProvider>
   );
 };
 
 export const getApolloClient = (
-  ctx?: any,
+  ctx?: ApolloClientContext,
   initialState?: NormalizedCacheObject
 ) => {
+  if (ctx && ctx.req) {
+    let { req } = ctx;
+    // Do something with the cookies here, maybe add a header for authentication 
+    req.cookies 
+  }
+
   const httpLink = createHttpLink({
     uri: "https://countries.trevorblades.com",
     fetch,

--- a/src/config.ts
+++ b/src/config.ts
@@ -118,6 +118,16 @@ export type Config = {
   customImports?: string;
 
   /**
+   * @description Add custom typing to context paramter
+   */
+  contextType?: string
+
+  /**
+   * @description Whether the caller is required to pass a context
+   */
+  contextTypeRequired?: boolean;
+
+  /**
    * @description Add apolloClient instance imports
    */
   apolloClientInstanceImport?: string;

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -65,6 +65,12 @@ export class ApolloNextSSRVisitor extends ClientSideBaseVisitor<
         rawConfig.apolloClientInstanceImport,
         ""
       ),
+      contextType: getConfigValue(
+        rawConfig.contextType, "any"
+      ),
+      contextTypeRequired: getConfigValue(
+        !!rawConfig.contextTypeRequired, false
+      ),
       apolloCacheImportFrom: getConfigValue(
         rawConfig.apolloCacheImportFrom,
         rawConfig.reactApolloVersion === 3
@@ -102,7 +108,7 @@ export class ApolloNextSSRVisitor extends ClientSideBaseVisitor<
 
     if (this.config.apolloClientInstanceImport) {
       this.imports.add(
-        `import { getApolloClient} from '${this.config.apolloClientInstanceImport}';`
+        `import { getApolloClient ${this.config.contextType ? ', ' + this.config.contextType : ''}} from '${this.config.apolloClientInstanceImport}';`
       );
     }
     if (!this.config.apolloClientInstanceImport) {
@@ -187,7 +193,7 @@ export class ApolloNextSSRVisitor extends ClientSideBaseVisitor<
     const getSSP = `export async function getServerPage${pageOperation}
     (options: Omit<Apollo.QueryOptions<${operationVariablesTypes}>, 'query'>, ${
       this.config.apolloClientInstanceImport
-        ? "ctx? :any"
+        ? `ctx${this.config.contextTypeRequired ? '' : '?'}: ${this.config.contextType}`
         : "apolloClient: Apollo.ApolloClient<NormalizedCacheObject>"
     } ){
         ${


### PR DESCRIPTION
Allows you to configure all `getServerPage` function to accept a custom `ctx` type instead of just `any`. 

### Motivation

I need a way to forward cookies to my GraphQL API so I need to read them from the `req` parameter passed into `GetServerSideProps` functions. This allows me to force all callers of `getServerPage` to pass that parameter along. 

