### PR TITLE
fix: pass full node into `convertName` to resolve `operationName`

### DIFF
--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -136,7 +136,7 @@ export class ApolloNextSSRVisitor extends ClientSideBaseVisitor<
     operationResultType: string,
     operationVariablesTypes: string
   ): string {
-    const operationName: string = this.convertName(node.name.value, {
+    const operationName: string = this.convertName(node, {
       useTypesPrefix: false,
     });
 


### PR DESCRIPTION
Addressing issue:
https://github.com/correttojs/graphql-codegen-apollo-next-ssr/issues/243