### PR TITLE
Avoid importing any from apolloClientInstanceImport

### DIFF
--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -108,7 +108,7 @@ export class ApolloNextSSRVisitor extends ClientSideBaseVisitor<
 
     if (this.config.apolloClientInstanceImport) {
       this.imports.add(
-        `import { getApolloClient ${this.config.contextType ? ', ' + this.config.contextType : ''}} from '${this.config.apolloClientInstanceImport}';`
+        `import { getApolloClient ${this.config.contextType !== 'any' ? ', ' + this.config.contextType : ''}} from '${this.config.apolloClientInstanceImport}';`
       );
     }
     if (!this.config.apolloClientInstanceImport) {


### PR DESCRIPTION
Using the latest version our build is failing because in the generated graphql the context type is imported, but it's not set and thus defaults to `any`.

```
import { getApolloClient, any } from '../apolloClient';
```

This doesn't work, because we don't export something called any. I assume your intention is to use TypeScript `any` here?

This is just a quick fix to filter `any` out. I wasn't sure if you wanted to use `contextTypeRequired` instead, so I figured to stay as close to the code as-is now.