### PR TITLE
Add `same-file` option to allow usage with `typescript-react-apollo`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import { RawClientSideBasePluginConfig } from "@graphql-codegen/visitor-plugin-c
  *
  * It extends the basic TypeScript plugins: `@graphql-codegen/typescript`, `@graphql-codegen/typescript-operations` - and thus shares a similar configuration.
  */
-export type ApolloNextSSRRawPluginConfig = RawClientSideBasePluginConfig &
+export type ApolloNextSSRRawPluginConfig = Omit<RawClientSideBasePluginConfig, 'importDocumentNodeExternallyFrom'> &
   Config;
 
 export type Config = {
@@ -142,4 +142,32 @@ export type Config = {
    * @description Custom React import
    */
   reactImport?: string;
+
+  /**
+   * @default ""
+   * @description This config should be used if `documentMode` is `external`. This has 3 usage:
+   * - any string: This would be the path to import document nodes from. This can be used if we want to manually create the document nodes e.g. Use `graphql-tag` in a separate file and export the generated document
+   * - 'near-operation-file': This is a special mode that is intended to be used with `near-operation-file` preset to import document nodes from those files. If these files are `.graphql` files, we make use of webpack loader.
+   * - 'same-file': This is a special mode that is intended to be used with the `typescript-operations` & `typescript-react-apollo` plugins to generate document nodes in the same files.
+   *
+   * @exampleMarkdown
+   * ```yml
+   * config:
+   *   documentMode: external
+   *   importDocumentNodeExternallyFrom: path/to/document-node-file
+   * ```
+   *
+   * ```yml
+   * config:
+   *   documentMode: external
+   *   importDocumentNodeExternallyFrom: near-operation-file
+   * ```
+   * 
+   * ```yml
+   * config:
+   *   documentMode: external
+   *   importDocumentNodeExternallyFrom: same-file
+   * ```
+   */
+  importDocumentNodeExternallyFrom?: string;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export const validate: PluginValidateFn<any> = async (
   outputFile: string
 ) => {
   if (extname(outputFile) !== ".tsx") {
-    throw new Error(`Plugin "react-apollo" requires extension to be ".tsx"!`);
+    throw new Error(`Plugin "apollo-next-ssr" requires extension to be ".tsx"!`);
   }
 };
 

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -4,7 +4,6 @@ import {
   ClientSideBasePluginConfig,
   getConfigValue,
   LoadedFragment,
-  OMIT_TYPE,
   DocumentMode,
 } from "@graphql-codegen/visitor-plugin-common";
 
@@ -96,11 +95,15 @@ export class ApolloNextSSRVisitor extends ClientSideBaseVisitor<
     if (this.config.withHOC) {
       this.imports.add(`import { NextPage } from 'next';`);
     }
-    this.imports.add(`import { NextRouter, useRouter } from 'next/router'`);
+    if (this.config.withHOC || this.config.withHooks) {
+      this.imports.add(`import { NextRouter, useRouter } from 'next/router'`);
+    }    
+    if (this.config.withHooks) {
+      this.imports.add(
+        `import { QueryHookOptions, useQuery } from '${this.config.apolloReactHooksImportFrom}';`
+      );
+    }
 
-    this.imports.add(
-      `import { QueryHookOptions, useQuery } from '${this.config.apolloReactHooksImportFrom}';`
-    );
     this.imports.add(
       `import * as Apollo from '${this.config.apolloImportFrom}';`
     );

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -98,7 +98,7 @@ export class ApolloNextSSRVisitor extends ClientSideBaseVisitor<
     if (this.config.withHOC || this.config.withHooks) {
       this.imports.add(`import { NextRouter, useRouter } from 'next/router'`);
     }    
-    if (this.config.withHooks) {
+    if (this.config.withHOC || this.config.withHooks) {
       this.imports.add(
         `import { QueryHookOptions, useQuery } from '${this.config.apolloReactHooksImportFrom}';`
       );

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -123,7 +123,11 @@ export class ApolloNextSSRVisitor extends ClientSideBaseVisitor<
       this.imports.add(this.config.customImports);
     }
 
-    const baseImports = super.getImports();
+    let baseImports = super.getImports();
+    if (this.config.importDocumentNodeExternallyFrom === 'same-file') {
+      baseImports = baseImports.filter(importStr => !importStr.startsWith('import * as Operations from '))
+    }
+
     const hasOperations = this._collectedOperations.length > 0;
 
     if (!hasOperations) {
@@ -134,7 +138,7 @@ export class ApolloNextSSRVisitor extends ClientSideBaseVisitor<
   }
 
   private getDocumentNodeVariable(documentVariableName: string): string {
-    return this.config.documentMode === DocumentMode.external
+    return this.config.documentMode === DocumentMode.external && this.config.importDocumentNodeExternallyFrom !== 'same-file'
       ? `Operations.${documentVariableName}`
       : documentVariableName;
   }


### PR DESCRIPTION
Possibly closes #86 

- Fix some unused imports (next router/useQuery when not using HoC or Hooks)
- Add new option `same-file` for `importDocumentNodeExternallyFrom` to allow use with  `typescript-react-apollo`.


Example config with `near-operation-file` preset, where `typescript-react-apollo` is used to generate Hooks and `apollo-next-ssr` is used to generate HoC and `getServerPage`, all in one file:

```yaml
schema: '${GRAPHQL_SERVER:http://localhost:3000/graphql}'
extensions:
  codegen:
    watch: true
    overwrite: true
    generates:
      apps/web-app/next:
        documents:
          - 'apps/web-app/src/**/*.graphql'
        preset: near-operation-file
        presetConfig:
          extension: .generated.tsx
          baseTypesPath: '~@project/types/graphql'
        plugins:
          - typescript-operations:
              reactApolloVersion: 3
          - typescript-react-apollo:
              reactApolloVersion: 3
          - apollo-next-ssr:
              documentMode: external
              importDocumentNodeExternallyFrom: 'same-file'
              apolloClientInstanceImport: '~/utils/apollo/withApollo'
              reactApolloVersion: 3

```

Yarn patch file if someone wants to test directly: https://gist.github.com/rohit-gohri/2a508c0dddaaff6c7bfbe4a855ccb500