### PR TITLE
chore: upgrade to support graphql v16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.0.tgz",
       "integrity": "sha512-d5RysTlJ7hmw5Tw4UxgxcY3lkMe92n8sXCcuLPAyIAHK6j8DefDwtGnVVDgOnv+RnEosulDJ9NPKQL27bDId0g==",
-      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
       }
@@ -17,7 +16,6 @@
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.0.tgz",
       "integrity": "sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==",
-      "dev": true,
       "requires": {
         "@babel/core": "^7.14.0",
         "@babel/generator": "^7.14.0",
@@ -42,7 +40,6 @@
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
           "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.16.7"
           }
@@ -50,14 +47,12 @@
         "@babel/compat-data": {
           "version": "7.18.5",
           "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.5.tgz",
-          "integrity": "sha512-BxhE40PVCBxVEJsSBhB6UWyAuqJRxGsAw8BdHMJ3AKGydcwuWW4kOO3HmqBQAdcq/OP+/DlTVxLvsCzRTnZuGg==",
-          "dev": true
+          "integrity": "sha512-BxhE40PVCBxVEJsSBhB6UWyAuqJRxGsAw8BdHMJ3AKGydcwuWW4kOO3HmqBQAdcq/OP+/DlTVxLvsCzRTnZuGg=="
         },
         "@babel/core": {
           "version": "7.18.5",
           "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
           "integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
-          "dev": true,
           "requires": {
             "@ampproject/remapping": "^2.1.0",
             "@babel/code-frame": "^7.16.7",
@@ -80,7 +75,6 @@
               "version": "7.18.4",
               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
               "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-              "dev": true,
               "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
@@ -92,7 +86,6 @@
           "version": "7.18.2",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
           "integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.18.2",
             "@jridgewell/gen-mapping": "^0.3.0",
@@ -103,7 +96,6 @@
               "version": "7.18.4",
               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
               "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-              "dev": true,
               "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
@@ -115,7 +107,6 @@
           "version": "7.18.2",
           "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz",
           "integrity": "sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==",
-          "dev": true,
           "requires": {
             "@babel/compat-data": "^7.17.10",
             "@babel/helper-validator-option": "^7.16.7",
@@ -127,7 +118,6 @@
           "version": "7.17.9",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
           "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
-          "dev": true,
           "requires": {
             "@babel/template": "^7.16.7",
             "@babel/types": "^7.17.0"
@@ -137,7 +127,6 @@
               "version": "7.18.4",
               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
               "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-              "dev": true,
               "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
@@ -149,7 +138,6 @@
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
           "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.16.7"
           },
@@ -158,7 +146,6 @@
               "version": "7.18.4",
               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
               "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-              "dev": true,
               "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
@@ -170,7 +157,6 @@
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
           "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.16.7"
           },
@@ -179,7 +165,6 @@
               "version": "7.18.4",
               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
               "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-              "dev": true,
               "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
@@ -191,7 +176,6 @@
           "version": "7.18.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.0.tgz",
           "integrity": "sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==",
-          "dev": true,
           "requires": {
             "@babel/helper-environment-visitor": "^7.16.7",
             "@babel/helper-module-imports": "^7.16.7",
@@ -207,7 +191,6 @@
               "version": "7.18.4",
               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
               "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-              "dev": true,
               "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
@@ -219,7 +202,6 @@
           "version": "7.18.2",
           "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.2.tgz",
           "integrity": "sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.18.2"
           },
@@ -228,7 +210,6 @@
               "version": "7.18.4",
               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
               "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-              "dev": true,
               "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
@@ -240,7 +221,6 @@
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
           "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.16.7"
           },
@@ -249,7 +229,6 @@
               "version": "7.18.4",
               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
               "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-              "dev": true,
               "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
@@ -260,20 +239,17 @@
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-          "dev": true
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
         },
         "@babel/helper-validator-option": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-          "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
-          "dev": true
+          "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ=="
         },
         "@babel/helpers": {
           "version": "7.18.2",
           "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.2.tgz",
           "integrity": "sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==",
-          "dev": true,
           "requires": {
             "@babel/template": "^7.16.7",
             "@babel/traverse": "^7.18.2",
@@ -284,7 +260,6 @@
               "version": "7.18.4",
               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
               "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-              "dev": true,
               "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
@@ -296,7 +271,6 @@
           "version": "7.17.12",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
           "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "chalk": "^2.0.0",
@@ -307,7 +281,6 @@
               "version": "2.4.2",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
               "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -319,14 +292,12 @@
         "@babel/parser": {
           "version": "7.18.5",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.5.tgz",
-          "integrity": "sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==",
-          "dev": true
+          "integrity": "sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw=="
         },
         "@babel/template": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
           "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.16.7",
             "@babel/parser": "^7.16.7",
@@ -337,7 +308,6 @@
               "version": "7.18.4",
               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
               "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-              "dev": true,
               "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
@@ -349,7 +319,6 @@
           "version": "7.18.5",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.5.tgz",
           "integrity": "sha512-aKXj1KT66sBj0vVzk6rEeAO6Z9aiiQ68wfDgge3nHhA/my6xMM/7HGQUNumKZaoa2qUPQ5whJG9aAifsxUKfLA==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.16.7",
             "@babel/generator": "^7.18.2",
@@ -366,14 +335,12 @@
             "@babel/helper-environment-visitor": {
               "version": "7.18.2",
               "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
-              "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==",
-              "dev": true
+              "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ=="
             },
             "@babel/types": {
               "version": "7.18.4",
               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
               "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-              "dev": true,
               "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
@@ -385,7 +352,6 @@
           "version": "4.21.0",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.0.tgz",
           "integrity": "sha512-UQxE0DIhRB5z/zDz9iA03BOfxaN2+GQdBYH/2WrSIWEUrnpzTPJbhqt+umq6r3acaPRTW1FNTkrcp0PXgtFkvA==",
-          "dev": true,
           "requires": {
             "caniuse-lite": "^1.0.30001358",
             "electron-to-chromium": "^1.4.164",
@@ -396,14 +362,12 @@
         "caniuse-lite": {
           "version": "1.0.30001358",
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
-          "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
-          "dev": true
+          "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw=="
         },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -413,7 +377,6 @@
               "version": "4.3.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-              "dev": true,
               "requires": {
                 "color-convert": "^2.0.1"
               }
@@ -422,7 +385,6 @@
               "version": "7.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-              "dev": true,
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -433,7 +395,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -441,44 +402,37 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "electron-to-chromium": {
           "version": "1.4.168",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.168.tgz",
-          "integrity": "sha512-yz247hclRBaP8ABB1hf9kL7AMfa+yC2hB9F3XF8Y87VWMnYgq4QYvV6acRACcDkTDxfGQ4GYK/aZPQiuFMGbaA==",
-          "dev": true
+          "integrity": "sha512-yz247hclRBaP8ABB1hf9kL7AMfa+yC2hB9F3XF8Y87VWMnYgq4QYvV6acRACcDkTDxfGQ4GYK/aZPQiuFMGbaA=="
         },
         "gensync": {
           "version": "1.0.0-beta.2",
           "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-          "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-          "dev": true
+          "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "json5": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-          "dev": true
+          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
         },
         "node-releases": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
-          "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
-          "dev": true
+          "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
         },
         "relay-runtime": {
           "version": "12.0.0",
           "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-12.0.0.tgz",
           "integrity": "sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.0.0",
             "fbjs": "^3.0.0",
@@ -488,8 +442,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -497,6 +450,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
       "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.10.1"
       }
@@ -510,6 +464,7 @@
       "version": "7.10.2",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.2.tgz",
       "integrity": "sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.1",
         "@babel/generator": "^7.10.2",
@@ -533,6 +488,7 @@
       "version": "7.10.2",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
       "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.2",
         "jsesc": "^2.5.1",
@@ -727,7 +683,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
       "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.16.7"
       },
@@ -735,14 +690,12 @@
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-          "dev": true
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
         },
         "@babel/types": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.7.tgz",
           "integrity": "sha512-E8HuV7FO9qLpx6OtoGfUQ2cjIYnbFwvZWYBS+87EwtdMvmUPJSwykpovFB+8insbpF0uJcpr8KMUi64XZntZcg==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
@@ -754,6 +707,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
       "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.10.1",
         "@babel/template": "^7.10.1",
@@ -764,6 +718,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
       "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.1"
       }
@@ -796,6 +751,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
       "integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.1"
       }
@@ -804,6 +760,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
       "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.1"
       }
@@ -812,6 +769,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
       "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
+      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.1",
         "@babel/helper-replace-supers": "^7.10.1",
@@ -826,6 +784,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
       "integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.1"
       }
@@ -839,6 +798,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
       "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
+      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.10.1",
         "@babel/helper-optimise-call-expression": "^7.10.1",
@@ -850,6 +810,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
       "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.10.1",
         "@babel/types": "^7.10.1"
@@ -883,6 +844,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
       "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.1"
       }
@@ -901,6 +863,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.1.tgz",
       "integrity": "sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.10.1",
         "@babel/traverse": "^7.10.1",
@@ -911,6 +874,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
       "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.1",
         "chalk": "^2.0.0",
@@ -920,7 +884,8 @@
     "@babel/parser": {
       "version": "7.10.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
-      "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
+      "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+      "dev": true
     },
     "@babel/plugin-proposal-class-properties": {
       "version": "7.14.5",
@@ -1967,6 +1932,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
       "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.1",
         "@babel/parser": "^7.10.1",
@@ -1977,6 +1943,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
       "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.1",
         "@babel/generator": "^7.10.1",
@@ -2774,57 +2741,34 @@
       }
     },
     "@graphql-codegen/visitor-plugin-common": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.7.4.tgz",
-      "integrity": "sha512-aaDoEudDD+B7DK/UwDSL2Fzej75N9hNJ3N8FQuTIeDyw6FNGWUxmkjVBLQGlzfnYfK8IYkdfYkrPn3Skq0pVxA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.9.1.tgz",
+      "integrity": "sha512-j9eGOSGt+sJcwv0ijhZiQ2cF/0ponscekNVoF+vHdOT4RB0qgOQxykPBk6EbKxIHECnkdV8ARdPVTA21A93/QQ==",
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.4.0",
         "@graphql-tools/optimize": "^1.0.1",
-        "@graphql-tools/relay-operation-optimizer": "^6.3.7",
+        "@graphql-tools/relay-operation-optimizer": "^6.4.14",
         "@graphql-tools/utils": "^8.3.0",
         "auto-bind": "~4.0.0",
         "change-case-all": "1.0.14",
         "dependency-graph": "^0.11.0",
         "graphql-tag": "^2.11.0",
         "parse-filepath": "^1.0.2",
-        "tslib": "~2.3.0"
+        "tslib": "~2.4.0"
       },
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.4.2.tgz",
-          "integrity": "sha512-LJNvwAPv/sKtI3RnRDm+nPD+JeOfOuSOS4FFIpQCMUCyMnFcchV/CPTTv7tT12fLUpEg6XjuFfDBvOwndti30Q==",
-          "requires": {
-            "@graphql-tools/utils": "^8.5.2",
-            "change-case-all": "1.0.14",
-            "common-tags": "1.8.2",
-            "import-from": "4.0.0",
-            "lodash": "~4.17.0",
-            "tslib": "~2.3.0"
-          }
-        },
         "@graphql-tools/utils": {
-          "version": "8.6.3",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.3.tgz",
-          "integrity": "sha512-CNyP7Uu7dlVMQ32IpHWOxz4yic9BYXXVkDhG0UdTKSszvzHdgMilemE9MpUrGzzBPsTe3aYTtNGyPUkyh9yTXA==",
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.8.0.tgz",
+          "integrity": "sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==",
           "requires": {
-            "tslib": "~2.3.0"
+            "tslib": "^2.4.0"
           }
-        },
-        "common-tags": {
-          "version": "1.8.2",
-          "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
-          "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="
-        },
-        "import-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
-          "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ=="
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -3454,27 +3398,27 @@
       }
     },
     "@graphql-tools/relay-operation-optimizer": {
-      "version": "6.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.3.7.tgz",
-      "integrity": "sha512-7UYnxPvIUDrdEKFAYrNF/YsoVBYMj6l3rwwuNs1jZyzAVZh8uq3TdvaFIIlcYvRychj45BEsg1jvRBvmhTaj3Q==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.0.tgz",
+      "integrity": "sha512-snqmdPiM2eBex6pijRFx4H9MPumVd8ZWM3y+aaRwzc73VUNnjHE4NyVZEEIdlbmJ2HoQ9Zrm9aFlHVMK7B59zg==",
       "requires": {
-        "@graphql-tools/utils": "^8.1.1",
-        "relay-compiler": "11.0.2",
-        "tslib": "~2.3.0"
+        "@ardatan/relay-compiler": "12.0.0",
+        "@graphql-tools/utils": "8.8.0",
+        "tslib": "^2.4.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.1.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.1.2.tgz",
-          "integrity": "sha512-3G+NIBR5mHjPm78jAD0l07JRE0XH+lr9m7yL/wl69jAzK0Jr/H+/Ok4ljEolI70iglz+ZhIShVPAwyesF6rnFg==",
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.8.0.tgz",
+          "integrity": "sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==",
           "requires": {
-            "tslib": "~2.3.0"
+            "tslib": "^2.4.0"
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -4627,7 +4571,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
       "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
-      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -4638,7 +4581,6 @@
           "version": "0.3.13",
           "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
           "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
-          "dev": true,
           "requires": {
             "@jridgewell/resolve-uri": "^3.0.3",
             "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -4649,26 +4591,22 @@
     "@jridgewell/resolve-uri": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
-      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==",
-      "dev": true
+      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg=="
     },
     "@jridgewell/set-array": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
-      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
-      "dev": true
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ=="
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.10.tgz",
-      "integrity": "sha512-Ht8wIW5v165atIX1p+JvKR5ONzUyF4Ac8DZIQ5kZs9zrb6M8SJNXpx1zn04rn65VjBMygRoMXcyYwNK0fT7bEg==",
-      "dev": true
+      "integrity": "sha512-Ht8wIW5v165atIX1p+JvKR5ONzUyF4Ac8DZIQ5kZs9zrb6M8SJNXpx1zn04rn65VjBMygRoMXcyYwNK0fT7bEg=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.2.tgz",
       "integrity": "sha512-9KzzH4kMjA2XmBRHfqG2/Vtl7s92l6uNDd0wW7frDE+EUvQFGqNXhWp0UGJjSkt3v2AYjzOZn1QO9XaTNJIt1Q==",
-      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -7357,7 +7295,8 @@
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -11739,6 +11678,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
       "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -12634,7 +12574,8 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -13112,7 +13053,8 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "path-root": {
       "version": "0.1.1",
@@ -13136,8 +13078,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -13501,85 +13442,6 @@
         "rc": "^1.2.8"
       }
     },
-    "relay-compiler": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-11.0.2.tgz",
-      "integrity": "sha512-nDVAURT1YncxSiDOKa39OiERkAr0DUcPmlHlg+C8zD+EiDo2Sgczf2R6cDsN4UcDvucYtkLlDLFErPwgLs8WzA==",
-      "requires": {
-        "@babel/core": "^7.0.0",
-        "@babel/generator": "^7.5.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/runtime": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "babel-preset-fbjs": "^3.3.0",
-        "chalk": "^4.0.0",
-        "fb-watchman": "^2.0.0",
-        "fbjs": "^3.0.0",
-        "glob": "^7.1.1",
-        "immutable": "~3.7.6",
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "relay-runtime": "11.0.2",
-        "signedsource": "^1.0.0",
-        "yargs": "^15.3.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "relay-runtime": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-11.0.2.tgz",
-      "integrity": "sha512-xxZkIRnL8kNE1cxmwDXX8P+wSeWLR+0ACFyAiAhvfWWAyjXb+bhjJ2FSsRGlNYfkqaTNEuDqpnodQV1/fF7Idw==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "fbjs": "^3.0.0",
-        "invariant": "^2.2.4"
-      }
-    },
     "remedial": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
@@ -13618,6 +13480,7 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -13738,7 +13601,8 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
     },
     "sentence-case": {
       "version": "2.1.1",
@@ -14591,7 +14455,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
       "integrity": "sha512-jnmO2BEGUjsMOe/Fg9u0oczOe/ppIDZPebzccl1yDWGLFP16Pa1/RM5wEoKYPG2zstNcDuAStejyxsOuKINdGA==",
-      "dev": true,
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "url": "https://github.com/correttojs/graphql-codegen-apollo-next-ssr"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^2.0.0",
-    "@graphql-codegen/visitor-plugin-common": "^2.0.0",
+    "@graphql-codegen/plugin-helpers": "^2.3.1",
+    "@graphql-codegen/visitor-plugin-common": "^2.9.1",
     "auto-bind": "~4.0.0"
   },
   "peerDependencies": {
-    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+    "graphql": "<17.0.0"
   },
   "main": "build/src/index.js",
   "devDependencies": {
@@ -36,7 +36,7 @@
     "@types/node": "17.0.30",
     "apollo-cache-inmemory": "1.6.6",
     "apollo-client": "2.6.10",
-    "graphql": "15.8.0",
+    "graphql": "<17.0.0",
     "graphql-codegen": "0.4.0",
     "jest": "27.5.1",
     "standard-version": "9.3.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   PluginFunction,
   PluginValidateFn,
   Types,
+  oldVisit,
 } from "@graphql-codegen/plugin-helpers";
 import { LoadedFragment } from "@graphql-codegen/visitor-plugin-common";
 import { RawClientSideBasePluginConfig } from "@graphql-codegen/visitor-plugin-common";
@@ -12,7 +13,6 @@ import {
   GraphQLSchema,
   Kind,
   concatAST,
-  visit,
 } from "graphql";
 
 import { ApolloNextSSRVisitor } from "./visitor";
@@ -29,9 +29,11 @@ export const plugin: PluginFunction<
   const allAst = concatAST(documents.map((v) => v.document));
 
   const allFragments: LoadedFragment[] = [
-    ...(allAst.definitions.filter(
-      (d) => d.kind === Kind.FRAGMENT_DEFINITION
-    ) as FragmentDefinitionNode[]).map((fragmentDef) => ({
+    ...(
+      allAst.definitions.filter(
+        (d) => d.kind === Kind.FRAGMENT_DEFINITION
+      ) as FragmentDefinitionNode[]
+    ).map((fragmentDef) => ({
       node: fragmentDef,
       name: fragmentDef.name.value,
       onType: fragmentDef.typeCondition.name.value,
@@ -46,7 +48,7 @@ export const plugin: PluginFunction<
     config,
     documents
   );
-  let visitorResult = visit(allAst, { leave: visitor });
+  let visitorResult = oldVisit(allAst, { leave: visitor });
 
   return {
     prepend: visitor.getImports(),
@@ -63,7 +65,9 @@ export const validate: PluginValidateFn<any> = async (
   outputFile: string
 ) => {
   if (extname(outputFile) !== ".tsx") {
-    throw new Error(`Plugin "apollo-next-ssr" requires extension to be ".tsx"!`);
+    throw new Error(
+      `Plugin "apollo-next-ssr" requires extension to be ".tsx"!`
+    );
   }
 };
 


### PR DESCRIPTION
## What does this change?
I was interested in using the latest version of graphql v16 in https://github.com/neontribe/gbptm

I followed the process linked to by Jack in this issue: #419, basing my changes here largely from this PR: https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/175

## Testing
I was able to successfully test this change locally by linking the package in my node_modules to the new build

Closes https://github.com/correttojs/graphql-codegen-apollo-next-ssr/issues/321, closes https://github.com/correttojs/graphql-codegen-apollo-next-ssr/issues/419